### PR TITLE
use new session in keystone

### DIFF
--- a/flameclient/managers.py
+++ b/flameclient/managers.py
@@ -47,22 +47,18 @@ class KeystoneManager(object):
         self.auth_token = auth_token
 
     def authenticate(self):
-        self.client().authenticate()
         self.auth_token = self.client().auth_token
 
     def client(self):
         if not self._client:
-            self._client = keystone_client.Client(
-                username=self.username,
-                password=self.password,
-                tenant_name=self.project,
-                auth_url=self.auth_url,
-                cert=self.cert,
-                key=self.key,
-                region_name=self.region_name,
-                insecure=self.insecure,
-                endpoint_type=self.endpoint_type,
-                token=self.auth_token)
+            from keystoneauth1.identity import v2
+            from keystoneauth1 import session
+            auth = v2.Password(auth_url=self.auth_url,
+                    username=self.username,
+                    password=self.password,
+                    tenant_name=self.project,)
+            self.sess = session.Session(auth=auth)
+            self._client = keystone_client.Client(session=self.sess)
         return self._client
 
     def set_client(self, client):
@@ -76,7 +72,8 @@ class KeystoneManager(object):
         return catalog[service_type][0][endpoint_type]
 
     def get_project_id(self):
-        return self.client().project_id
+        self.client()
+        return self.sess.get_project_id()
 
 
 class NeutronManager(object):
@@ -89,11 +86,7 @@ class NeutronManager(object):
     def client(self):
         if not self._client:
             # Create the client
-            self._client = neutron_client.Client(
-                auth_url=self.keystone_mgr.auth_url,
-                insecure=self.keystone_mgr.insecure,
-                endpoint_url=self.keystone_mgr.get_endpoint('network'),
-                token=self.keystone_mgr.auth_token)
+            self._client = neutron_client.Client(session=self.keystone_mgr.sess)
         if not self._project_id:
             self._project_id = self.keystone_mgr.get_project_id()
         return self._client
@@ -146,15 +139,7 @@ class NovaManager(object):
         if not self._client:
             self._client = nova_client.Client(
                 '2',
-                self.keystone_mgr.username,
-                self.keystone_mgr.auth_token,
-                self.keystone_mgr.project,
-                self.keystone_mgr.auth_url,
-                region_name=self.keystone_mgr.region_name,
-                insecure=self.keystone_mgr.insecure,
-                endpoint_type=self.keystone_mgr.endpoint_type,
-                auth_token=self.keystone_mgr.auth_token
-            )
+                session=self.keystone_mgr.sess)
         return self._client
 
     def set_client(self, client):
@@ -195,20 +180,8 @@ class CinderManager(object):
 
     def client(self):
         if self.defined and not self._client:
-            try:
-                cinder_url = self.keystone_mgr.get_endpoint("volumev2")
-            except KeyError:
-                cinder_url = self.keystone_mgr.get_endpoint("volume")
             client = cinder_client.Client(
-                self.keystone_mgr.username,
-                self.keystone_mgr.auth_token,
-                project_id=self.keystone_mgr.project,
-                auth_url=cinder_url,
-                http_log_debug=True,
-                insecure=self.keystone_mgr.insecure
-            )
-            client.client.auth_token = self.keystone_mgr.auth_token
-            client.client.management_url = cinder_url
+                session=self.keystone_mgr.sess)
             self._client = client
         return self._client
 


### PR DESCRIPTION
Makes it use the new session in keystone to work with newer versions of
the python-*client modules.

Signed-off-by: Robert Marklund <robbelibobban@gmail.com>